### PR TITLE
Add include/exclude filters to looprc

### DIFF
--- a/lib/loop.js
+++ b/lib/loop.js
@@ -11,7 +11,7 @@ module.exports = (options, cb) => {
   const cwd = options.dir || process.cwd();
 
   var dirs = options.directories || listDirectories(options.looprc, cwd);
-  var looprc = options["looprc"];
+  var looprc = options["looprc"] || [];
 
   options.exclude = options.exclude || looprc.exclude || getArgsForFlag(process.argv, '--exclude'),
   options.excludeOnly = options.excludeOnly || looprc.excludeOnly || getArgsForFlag(process.argv, '--exclude-only'),

--- a/lib/loop.js
+++ b/lib/loop.js
@@ -1,6 +1,6 @@
 const chalk = require('chalk');
 const expandCommand = require('../lib/expandCommand');
-const getArgsForFlag = require('../lib/getArgsForFlag'); 
+const getArgsForFlag = require('../lib/getArgsForFlag');
 const listDirectories = require('../lib/listDirectories');
 const mapExec = require('../lib/mapExec');
 const path = require('path');
@@ -11,11 +11,12 @@ module.exports = (options, cb) => {
   const cwd = options.dir || process.cwd();
 
   var dirs = options.directories || listDirectories(options.looprc, cwd);
+  var looprc = options["looprc"];
 
-  options.exclude = options.exclude || getArgsForFlag(process.argv, '--exclude'),
-  options.excludeOnly = options.excludeOnly || getArgsForFlag(process.argv, '--exclude-only'),
-  options.include = options.include || getArgsForFlag(process.argv, '--include'),
-  options.includeOnly = options.includeOnly || getArgsForFlag(process.argv, '--include-only')
+  options.exclude = options.exclude || looprc.exclude || getArgsForFlag(process.argv, '--exclude'),
+  options.excludeOnly = options.excludeOnly || looprc.excludeOnly || getArgsForFlag(process.argv, '--exclude-only'),
+  options.include = options.include || looprc.include || getArgsForFlag(process.argv, '--include'),
+  options.includeOnly = options.includeOnly || looprc.includeOnly || getArgsForFlag(process.argv, '--include-only')
 
   if (options.excludeOnly) {
     dirs = listDirectories({ ignore: options.excludeOnly }, options.dir)
@@ -36,11 +37,11 @@ module.exports = (options, cb) => {
   mapExec(commands, (err, commandOutputs) => {
     const results = commandOutputs.reduce((logMessage, commandOutput, index) => {
       const color = commandOutput.error ? 'red' : 'green';
-      const code = commandOutput.error && commandOutput.error.code !== 0 
-        ? commandOutput.error.code 
+      const code = commandOutput.error && commandOutput.error.code !== 0
+        ? commandOutput.error.code
         : null;
       const output = commandOutput.output || commandOutput.error;
-      return `${logMessage}\n${output}`; 
+      return `${logMessage}\n${output}`;
     }, '');
     if (cb) return cb(null, results);
   });

--- a/lib/loop.js
+++ b/lib/loop.js
@@ -13,10 +13,10 @@ module.exports = (options, cb) => {
   var dirs = options.directories || listDirectories(options.looprc, cwd);
   var looprc = options["looprc"] || [];
 
-  options.exclude = options.exclude || looprc.exclude || getArgsForFlag(process.argv, '--exclude'),
-  options.excludeOnly = options.excludeOnly || looprc.excludeOnly || getArgsForFlag(process.argv, '--exclude-only'),
-  options.include = options.include || looprc.include || getArgsForFlag(process.argv, '--include'),
-  options.includeOnly = options.includeOnly || looprc.includeOnly || getArgsForFlag(process.argv, '--include-only')
+  options.exclude = options.exclude || getArgsForFlag(process.argv, '--exclude') || looprc.exclude,
+  options.excludeOnly = options.excludeOnly || getArgsForFlag(process.argv, '--exclude-only') ||  looprc.excludeOnly,
+  options.include = options.include || getArgsForFlag(process.argv, '--include') || looprc.include,
+  options.includeOnly = options.includeOnly || getArgsForFlag(process.argv, '--include-only') || looprc.includeOnly
 
   if (options.excludeOnly) {
     dirs = listDirectories({ ignore: options.excludeOnly }, options.dir)


### PR DESCRIPTION
This will allow you to use `include`, `includeOnly`, `exclude`, `excludeOnly` from the `.looprc` file.

Ex:
```
{
  "ignore": [ ".git", ".vagrant", ".vscode", "node_modules" ],
  "includeOnly": ["project-1", "project-4"],
  "exclude": ["project-2"]
}
```