### PR TITLE
Feature/exit codes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 npm-debug.log
+yarn-error.log

--- a/bin/loop
+++ b/bin/loop
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 const copyFile = require('../lib/copyFile');
-const debug = require('debug')('loop');
+const debug = require('debug')('@essential-projects/loop');
 const fs = require('fs');
 const loop = require('../lib/loop');
 const path = require('path');

--- a/bin/loop
+++ b/bin/loop
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 const copyFile = require('../lib/copyFile');
-const debug = require('debug')('@essential-projects/loop');
+const debug = require('debug')('loop');
 const fs = require('fs');
 const loop = require('../lib/loop');
 const path = require('path');
@@ -61,6 +61,8 @@ if (cwd[0] !== '/') {
 debug(`running loop ${argv._} in cwd ${cwd}`);
 
 const command = process.argv[2];
+const exitOnError = process.argv.indexOf('--exit-on-error') >= 0;
+const exitOnAggregatedError = process.argv.indexOf('--exit-on-aggregated-error') >= 0;
 
 if (argv.init) {
   copyFile(path.resolve(__dirname, '..', 'support', LOOPRC), path.resolve(cwd, LOOPRC));
@@ -92,5 +94,12 @@ if (buffer) {
 loop({
   dir: cwd,
   command,
+  exitOnError,
+  exitOnAggregatedError,
   looprc,
+}, (errorOccured) => {
+  if (exitOnAggregatedError && errorOccured) {
+    console.log('an error occured during loop execution - exiting process');
+    process.exit(1);
+  }
 });

--- a/lib/expandCommand.js
+++ b/lib/expandCommand.js
@@ -1,8 +1,10 @@
-module.exports = function (dirs, command) {
+module.exports = function (dirs, command, options) {
   return dirs.map((dir) => {
     return {
       dir,
-      command
+      command,
+      exitOnError: options.exitOnError,
+      exitOnAggregatedError: options.exitOnAggregatedError,
     }; 
   });
 };

--- a/lib/listDirectories.js
+++ b/lib/listDirectories.js
@@ -1,4 +1,4 @@
-const debug = require('debug')('loop:listDirectories');
+const debug = require('debug')('@essential-projects/loop:listDirectories');
 const fs = require('fs');
 const path = require('path');
 

--- a/lib/listDirectories.js
+++ b/lib/listDirectories.js
@@ -1,4 +1,4 @@
-const debug = require('debug')('@essential-projects/loop:listDirectories');
+const debug = require('debug')('loop:listDirectories');
 const fs = require('fs');
 const path = require('path');
 

--- a/lib/loop.js
+++ b/lib/loop.js
@@ -74,7 +74,7 @@ module.exports = (options, cb, errorCb) => {
   }, (error) => {
 
     if (options.exitOnError) {
-      console.log(`a child command executed by loop encountered an error:\n${commandOutput.error}`);
+      console.log(`a child command executed by loop encountered an error:\n${error}`);
       process.exit(1);
     }
 

--- a/lib/loop.js
+++ b/lib/loop.js
@@ -15,7 +15,9 @@ module.exports = (options, cb) => {
   options.exclude = options.exclude || getArgsForFlag(process.argv, '--exclude'),
   options.excludeOnly = options.excludeOnly || getArgsForFlag(process.argv, '--exclude-only'),
   options.include = options.include || getArgsForFlag(process.argv, '--include'),
-  options.includeOnly = options.includeOnly || getArgsForFlag(process.argv, '--include-only')
+  options.includeOnly = options.includeOnly || getArgsForFlag(process.argv, '--include-only'),
+  options.exitOnError = options.exitOnError || getArgsForFlag(process.argv, '--exit-on-error'),
+  options.exitOnAggregatedErrors = options.exitOnAggregatedErrors || getArgsForFlag(process.argv, '--exit-on-aggregated-errors')
 
   if (options.excludeOnly) {
     dirs = listDirectories({ ignore: options.excludeOnly }, options.dir)
@@ -33,6 +35,8 @@ module.exports = (options, cb) => {
 
   const commands = expandCommand(dirs, options.command);
 
+  let errorCodes = [];
+
   mapExec(commands, (err, commandOutputs) => {
     const results = commandOutputs.reduce((logMessage, commandOutput, index) => {
       const color = commandOutput.error ? 'red' : 'green';
@@ -40,8 +44,22 @@ module.exports = (options, cb) => {
         ? commandOutput.error.code 
         : null;
       const output = commandOutput.output || commandOutput.error;
+
+      if (code && options.exitOnError) {
+        process.exit(code);
+      }
+
+      if (code) {
+        errorCodes.push(code);
+      }
+
       return `${logMessage}\n${output}`; 
     }, '');
+
+    if (options.exitOnAggregatedErrors && errorCodes.length > 0) {
+      process.exit(1);
+    }
+
     if (cb) return cb(null, results);
   });
 

--- a/lib/loop.js
+++ b/lib/loop.js
@@ -6,7 +6,7 @@ const mapExec = require('../lib/mapExec');
 const path = require('path');
 const _ = require('lodash');
 
-module.exports = (options, cb) => {
+module.exports = (options, cb, errorCb) => {
 
   const cwd = options.dir || process.cwd();
 
@@ -39,9 +39,13 @@ module.exports = (options, cb) => {
   });
 
   let commandOutputsWithErrors = [];
-  let errorOccured = false;
 
   mapExec(commands, (err, commandOutputs) => {
+
+    if (options.exitOnAggregatedError && commandOutputsWithErrors.length > 0) {
+      console.log(`one or more child commands executed by loop encountered an error:\n${commandOutputsWithErrors.join('\n')}`);
+      process.exit(1);
+    }
 
     const results = commandOutputs.reduce((logMessage, commandOutput, index) => {
       const color = commandOutput.error ? 'red' : 'green';
@@ -56,7 +60,6 @@ module.exports = (options, cb) => {
           process.exit(1);
         }
         commandOutputsWithErrors.push(commandOutput.error);
-        errorOccured = true;
       }
 
       if (code && options.exitOnError) {
@@ -66,11 +69,16 @@ module.exports = (options, cb) => {
       return `${logMessage}\n${output}`; 
     }, '');
 
-    if (cb && errorOccured) {
-      return cb(new Error(`one or more child commands executed by loop encountered an error:\n${commandOutputsWithErrors.join('\n')}`));
+    if (cb) return cb(null, results);
+
+  }, (error) => {
+
+    if (options.exitOnError) {
+      console.log(`a child command executed by loop encountered an error:\n${commandOutput.error}`);
+      process.exit(1);
     }
 
-    if (cb) return cb(null, results);
+    commandOutputsWithErrors.push(error);
   });
 
 };

--- a/lib/loop.js
+++ b/lib/loop.js
@@ -38,7 +38,7 @@ module.exports = (options, cb) => {
     exitOnAggregatedError: options.exitOnAggregatedError,
   });
 
-  let errorCodes = [];
+  let commandOutputsWithErrors = [];
   let errorOccured = false;
 
   mapExec(commands, (err, commandOutputs) => {
@@ -52,8 +52,10 @@ module.exports = (options, cb) => {
 
       if (commandOutput.error) {
         if (options.exitOnError) {
+          console.log(`a child command executed by loop encountered an error:\n${commandOutput.error}`);
           process.exit(1);
         }
+        commandOutputsWithErrors.push(commandOutput.error);
         errorOccured = true;
       }
 
@@ -61,15 +63,11 @@ module.exports = (options, cb) => {
         process.exit(code);
       }
 
-      if (code) {
-        errorCodes.push(code);
-      }
-
       return `${logMessage}\n${output}`; 
     }, '');
 
     if (cb && errorOccured) {
-      return cb(errorOccured);
+      return cb(new Error(`one or more child commands executed by loop encountered an error:\n${commandOutputsWithErrors.join('\n')}`));
     }
 
     if (cb) return cb(null, results);

--- a/lib/loop.js
+++ b/lib/loop.js
@@ -33,17 +33,29 @@ module.exports = (options, cb) => {
     dirs = _.union(dirs, options.include.map((i) => { return path.resolve(cwd, i); })).sort();
   }
 
-  const commands = expandCommand(dirs, options.command);
+  const commands = expandCommand(dirs, options.command, {
+    exitOnError: options.exitOnError,
+    exitOnAggregatedError: options.exitOnAggregatedError,
+  });
 
   let errorCodes = [];
+  let errorOccured = false;
 
   mapExec(commands, (err, commandOutputs) => {
+
     const results = commandOutputs.reduce((logMessage, commandOutput, index) => {
       const color = commandOutput.error ? 'red' : 'green';
       const code = commandOutput.error && commandOutput.error.code !== 0 
         ? commandOutput.error.code 
         : null;
       const output = commandOutput.output || commandOutput.error;
+
+      if (commandOutput.error) {
+        if (options.exitOnError) {
+          process.exit(1);
+        }
+        errorOccured = true;
+      }
 
       if (code && options.exitOnError) {
         process.exit(code);
@@ -56,8 +68,8 @@ module.exports = (options, cb) => {
       return `${logMessage}\n${output}`; 
     }, '');
 
-    if (options.exitOnAggregatedErrors && errorCodes.length > 0) {
-      process.exit(1);
+    if (cb && errorOccured) {
+      return cb(errorOccured);
     }
 
     if (cb) return cb(null, results);

--- a/lib/mapExec.js
+++ b/lib/mapExec.js
@@ -1,6 +1,6 @@
 const async = require('async');
 const chalk = require('chalk');
-const exec = require('meta-exec');
+const exec = require('@essential-projects/meta-exec');
 const path = require('path');
 
 module.exports = (commands, cb) => {

--- a/lib/mapExec.js
+++ b/lib/mapExec.js
@@ -1,14 +1,16 @@
 const async = require('async');
 const chalk = require('chalk');
-const exec = require('@essential-projects/meta-exec');
+const exec = require('meta-exec');
 const path = require('path');
 
 module.exports = (commands, cb) => {
 
-  async.map(commands, (cmd, cb) => {
-    exec({
+  return async.map(commands, (cmd, cb) => {
+    return exec({
       command: cmd.command,
-      dir: cmd.dir
+      dir: cmd.dir,
+      exitOnError: cmd.exitOnError,
+      exitOnAggregatedError: cmd.exitOnAggregatedError,
     }, cb);
   }, cb);
 

--- a/lib/mapExec.js
+++ b/lib/mapExec.js
@@ -3,7 +3,7 @@ const chalk = require('chalk');
 const exec = require('meta-exec');
 const path = require('path');
 
-module.exports = (commands, cb) => {
+module.exports = (commands, cb, errorCb) => {
 
   return async.map(commands, (cmd, cb) => {
     return exec({
@@ -11,7 +11,7 @@ module.exports = (commands, cb) => {
       dir: cmd.dir,
       exitOnError: cmd.exitOnError,
       exitOnAggregatedError: cmd.exitOnAggregatedError,
-    }, cb);
+    }, cb, errorCb);
   }, cb);
 
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "loop through commands in fun and amazing ways!",
   "main": "./index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "loop through commands in fun and amazing ways!",
   "main": "./index.js",
   "bin": {
@@ -28,7 +28,7 @@
     "chalk": "^1.1.3",
     "debug": "^2.3.3",
     "lodash": "^4.17.2",
-    "meta-exec": "^0.0.7",
+    "@essential-projects/meta-exec": "^0.0.7",
     "mocha": "^3.2.0",
     "should": "^11.1.2",
     "yargs": "^6.5.0"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@essential-projects/loop",
+  "publishConfig": {
+    "registry": "https://www.npmjs.com"
+  },
   "version": "3.0.2",
   "description": "loop through commands in fun and amazing ways!",
   "main": "./index.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "loop",
+  "name": "@essential-projects/loop",
   "version": "3.0.2",
   "description": "loop through commands in fun and amazing ways!",
   "main": "./index.js",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "loop through commands in fun and amazing ways!",
   "main": "./index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@essential-projects/loop",
+  "name": "loop",
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
@@ -28,7 +28,7 @@
     "chalk": "^1.1.3",
     "debug": "^2.3.3",
     "lodash": "^4.17.2",
-    "@essential-projects/meta-exec": "^0.0.7",
+    "meta-exec": "^0.0.10",
     "mocha": "^3.2.0",
     "should": "^11.1.2",
     "yargs": "^6.5.0"


### PR DESCRIPTION
This adds two options `exit-on-error` and `exit-on-aggregated-error`.

`exit-on-error` directly cancels everything with `process.exit(1)` as soon as an error occurs on a sub command.

`exit-on-aggregated-error` waits until all sub commands have run and then exits with `process.exit(1)`.

I added the options, because without them I didn't find any way to have the exit code on the original `meta` call reflect that errors occured on one of the commands.

This PR also involves PRs for `meta-exec`, `meta-loop` and `meta`.

I didn't clean up the commit history and I had to do some version changes during the process to test the changes on my local setup.

I'll gladly clean up everything as soon as you reviewed it, but would like to keep it until then for testing purposes. If you want I can also provide you with a test setup if that might be an issue (wasn't easy for me ;).